### PR TITLE
Add flag to make chunk ordering optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ new ExtractTextPlugin([id: string], filename: string, [options])
   * `allChunks` extract from all additional chunks too (by default it extracts only from the initial chunk(s))
   * `disable` disables the plugin
   * `isCacheable` defaults to `true` but if you pass `false` loader will run `this.cacheable(false)`
+  * `ignoreOrder` defaults to `false` but for assets types where chunk order doesn't matter (local scoped CSS) you may want to set it to `true`.
 
 The `ExtractTextPlugin` generates an output file per entry, so you must use `[name]`, `[id]` or `[contenthash]` when using multiple entries.
 

--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ ExtractTextPlugin.prototype.apply = function(compiler) {
 			extractedChunks.forEach(function(extractedChunk) {
 				if(extractedChunk.modules.length) {
 					extractedChunk.modules.sort(function(a, b) {
-						if(isInvalidOrder(a, b)) {
+						if(options.ignoreOrder && isInvalidOrder(a, b)) {
 							compilation.errors.push(new OrderUndefinedError(a.getOriginalModule()));
 							compilation.errors.push(new OrderUndefinedError(b.getOriginalModule()));
 						}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extract-text-webpack-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Tobias Koppers @sokra",
   "description": "Extract text from bundle into a file.",
   "peerDependencies": {


### PR DESCRIPTION
Allows us to silence a webpack error for cases where the plugin can't reason about chunk ordering but it also isn't necessary (locally scoped CSS for instance).
